### PR TITLE
Added sanity check to the broken select optimizations.

### DIFF
--- a/build_deps.sh
+++ b/build_deps.sh
@@ -39,7 +39,7 @@ svn co https://llvm.org/svn/llvm-project/cfe/${llvm_branch} $llvmdir/tools/clang
 svn co https://llvm.org/svn/llvm-project/compiler-rt/${llvm_branch} $llvmdir/projects/compiler-rt
 # Disable the broken select -> logic optimizations
 cat <<EOF | patch $llvmdir/lib/Transforms/InstCombine/InstCombineSelect.cpp
---- lib/Transforms/InstCombine/InstCombineSelect.cpp    (revision 326606)
+--- lib/Transforms/InstCombine/InstCombineSelect.cpp    (revision 326856)
 +++ lib/Transforms/InstCombine/InstCombineSelect.cpp    (working copy)
 @@ -1334,7 +1334,7 @@
      Worklist.Add(Cond);
@@ -50,13 +50,32 @@ cat <<EOF | patch $llvmdir/lib/Transforms/InstCombine/InstCombineSelect.cpp
    if (SelType->isIntOrIntVectorTy(1) &&
        TrueVal->getType() == CondVal->getType()) {
      if (match(TrueVal, m_One())) {
-@@ -1370,7 +1370,7 @@
+@@ -1370,7 +1370,6 @@
      if (match(FalseVal, m_Not(m_Specific(CondVal))))
        return BinaryOperator::CreateOr(TrueVal, FalseVal);
    }
 -
-+#endif
    // Selecting between two integer or vector splat integer constants?
+   //
+   // Note that we don't handle a scalar select of vectors:
+@@ -1378,7 +1377,8 @@
+   // because that may need 3 instructions to splat the condition value:
+   // extend, insertelement, shufflevector.
+   if (SelType->isIntOrIntVectorTy() &&
+-      CondVal->getType()->isVectorTy() == SelType->isVectorTy()) {
++      CondVal->getType()->isVectorTy() == SelType->isVectorTy() &&
++      CondVal->getType()->getScalarSizeInBits() < SelType->getScalarSizeInBits()) {
+     // select C, 1, 0 -> zext C to int
+     if (match(TrueVal, m_One()) && match(FalseVal, m_Zero()))
+       return new ZExtInst(CondVal, SelType);
+@@ -1399,6 +1399,7 @@
+       return new SExtInst(NotCond, SelType);
+     }
+   }
++#endif
+
+   // See if we are selecting two values based on a comparison of the two values.
+   if (FCmpInst *FCI = dyn_cast<FCmpInst>(CondVal)) {
 EOF
 mkdir -p $llvm_builddir
 


### PR DESCRIPTION
This blocks from transforming select i1 C, i1 1, i1 0 => zext i1 C to i1.